### PR TITLE
Add LSST cvmfs repository sw.lsst.eu

### DIFF
--- a/repos/sw.lsst.eu.json
+++ b/repos/sw.lsst.eu.json
@@ -1,0 +1,5 @@
+{
+  "name": "Vera C. Rubin observatory, LSST science pipelines",
+  "fqrn": "sw.lsst.eu",
+  "url": "http://cclssts1.in2p3.fr/cvmfs/"
+}

--- a/repos/sw.lsst.eu.json
+++ b/repos/sw.lsst.eu.json
@@ -1,5 +1,5 @@
 {
-  "name": "Vera C. Rubin observatory, LSST science pipelines",
+  "name": "Vera C. Rubin observatory | Legacy Survey of Space and Time (LSST) science pipelines",
   "fqrn": "sw.lsst.eu",
   "url": "http://cclssts1.in2p3.fr/cvmfs/"
 }


### PR DESCRIPTION
Hi Jakob et al.,

please consider including the information about the _Rubin observatory LSST science pipelines_ cvmfs repository `sw.lsst.eu` so that it can be monitored by CERN's repository monitor.

More information about this repository can be found at [https://sw.lsst.eu](https://sw.lsst.eu)