### PR TITLE
added metadata JSONs for the hdf and container repos at DESY as test run

### DIFF
--- a/repos/containers.desy.de.json
+++ b/repos/containers.desy.de.json
@@ -1,0 +1,5 @@
+{
+        "name": "Singularity Container Repository @ DESY",
+        "fqrn": "containers.desy.de",
+        "url": "http://grid-cvmfs-one.desy.de"
+}

--- a/repos/hdf.desy.de.json
+++ b/repos/hdf.desy.de.json
@@ -1,0 +1,5 @@
+{
+        "name": "Singularity Container Repository @ DESY",
+        "fqrn": "containers.desy.de",
+        "url": "http://grid-cvmfs-one.desy.de"
+}

--- a/repos/hdf.desy.de.json
+++ b/repos/hdf.desy.de.json
@@ -1,5 +1,5 @@
 {
-        "name": "Singularity Container Repository @ DESY",
-        "fqrn": "containers.desy.de",
+        "name": "Demonstrator Repository for the Helmholtz Data Federation",
+        "fqrn": "hdf.desy.de",
         "url": "http://grid-cvmfs-one.desy.de"
 }


### PR DESCRIPTION
Hi,

for a test run, I added metadata to our minor/toy repos (hdf.desy.de, containers.desy.de), i.e., the generic info
  http://hdf-cvmfs.desy.de/cvmfs/info/v1/meta.json {repositories.json}
and updated the per-repo jsons.
So far,  we generate the JSONs automatically as a puppet template from Hiera infos - would it be reasonable to auto-commit/push any changes to a fork and create a pull request - or would that maybe overkill (I guess, the info would not change much)

btw:
where can I actual find the repo meta JSONs on the server? I tried mutations of
http://hdf-cvmfs.desy.de/cvmfs/info/v1/hdf.desy.de.json
and such but without success. The documentation under https://cvmfs.readthedocs.io/en/latest/cpt-servermeta.html just mentions the general meta and repository jsons urls

Cheers,
  Thomas