### PR TITLE
Add software.pacific-neutrino.org

### DIFF
--- a/repos/software.pacific-neutrino.org.json
+++ b/repos/software.pacific-neutrino.org.json
@@ -1,0 +1,5 @@
+{
+        "name": "Software for the Pacific Ocean Neutrino Experiment",
+        "fqrn": "software.pacific-neutrino.org",
+        "url": "http://object-arbutus.cloud.computecanada.ca:8880/cvmfs-software.pacific-neutrino.org"
+}


### PR DESCRIPTION

The URL for the manifest is http://object-arbutus.cloud.computecanada.ca:8880/cvmfs-software.pacific-neutrino.org/software.pacific-neutrino.org/.cvmfspublished